### PR TITLE
Implement fix for redis-oplog issue #367.

### DIFF
--- a/lib/cache/lib/extractFieldsFromFilters.js
+++ b/lib/cache/lib/extractFieldsFromFilters.js
@@ -19,14 +19,14 @@ function extractFieldsFromFilters(filters) {
     deepFilterFieldsArray.forEach(field => {
         if (filters[field]) {
             filters[field].forEach(element => {
-                _.union(filterFields, extractFieldsFromFilters(element));
+                filterFields = _.union(filterFields, extractFieldsFromFilters(element));
             });
         }
     });
 
     deepFilterFieldsObject.forEach(field => {
         if (filters[field]) {
-            _.union(filterFields, extractFieldsFromFilters(filters[field]));
+            filterFields = _.union(filterFields, extractFieldsFromFilters(filters[field]));
         }
     });
 


### PR DESCRIPTION
This fixes the issue mentioned [here](https://github.com/cult-of-coders/redis-oplog/issues/367) (with the fix suggested there). Without the fix, the use of `_.union` is a no-op and so fields that appear only under an operator like `$or` or `$and` won't be found.